### PR TITLE
feature_chronopost_mask_url_1219723

### DIFF
--- a/ChronopostHomeDelivery.php
+++ b/ChronopostHomeDelivery.php
@@ -49,6 +49,12 @@ class ChronopostHomeDelivery extends AbstractDeliveryModuleWithState
     /** @var string */
     const DOMAIN_NAME = 'chronoposthomedelivery';
 
+    /** Thelia module code (class name) — used in delivery module comparisons */
+    const MODULE_CODE = 'ChronopostHomeDelivery';
+
+    /** Back-office i18n domain (matches I18n/backOffice/default/) */
+    const BO_DOMAIN_NAME = 'chronoposthomedelivery.bo.default';
+
     const CHRONOPOST_CONFIRMATION_MESSAGE_NAME = 'chronopost_home_delivery_confirmation_message_name';
 
     const CHRONOPOST_TAX_RULE_ID = 'chronopost_home_delivery_tax_rule_id';

--- a/Config/ChronopostHomeDeliveryConst.php
+++ b/Config/ChronopostHomeDeliveryConst.php
@@ -28,6 +28,9 @@ class ChronopostHomeDeliveryConst
     /** Tracking link mask URL (start.MASK_SEPARATOR.end concatenated) */
     const CHRONOPOST_HOME_DELIVERY_MASK_URL                       = "chronopost_home_delivery_mask_url";
 
+    /** Placeholder inserted in the tracking URL — replaced by the parcel reference at display time */
+    const MASK_SEPARATOR                                          = '{REF}';
+
     /** WSDL for the Chronopost Shipping Service */
     const CHRONOPOST_HOME_DELIVERY_SHIPPING_SERVICE_WSDL              = "https://ws.chronopost.fr/shipping-cxf/ShippingServiceWS?wsdl";
     //const CHRONOPOST_HOME_DELIVERY_RELAY_SEARCH_SERVICE_WSDL          = "https://ws.chronopost.fr/recherchebt-ws-cxf/PointRelaisServiceWS?wsdl";

--- a/Config/ChronopostHomeDeliveryConst.php
+++ b/Config/ChronopostHomeDeliveryConst.php
@@ -25,6 +25,9 @@ class ChronopostHomeDeliveryConst
     const CHRONOPOST_HOME_DELIVERY_CODE_CLIENT                    = "chronopost_home_delivery_code";
     const CHRONOPOST_HOME_DELIVERY_PASSWORD                       = "chronopost_home_delivery_password";
 
+    /** Tracking link mask URL (start.MASK_SEPARATOR.end concatenated) */
+    const CHRONOPOST_HOME_DELIVERY_MASK_URL                       = "chronopost_home_delivery_mask_url";
+
     /** WSDL for the Chronopost Shipping Service */
     const CHRONOPOST_HOME_DELIVERY_SHIPPING_SERVICE_WSDL              = "https://ws.chronopost.fr/shipping-cxf/ShippingServiceWS?wsdl";
     //const CHRONOPOST_HOME_DELIVERY_RELAY_SEARCH_SERVICE_WSDL          = "https://ws.chronopost.fr/recherchebt-ws-cxf/PointRelaisServiceWS?wsdl";
@@ -57,6 +60,9 @@ class ChronopostHomeDeliveryConst
             /** Chronopost basic informations */
             self::CHRONOPOST_HOME_DELIVERY_CODE_CLIENT                => ChronopostHomeDelivery::getConfigValue(self::CHRONOPOST_HOME_DELIVERY_CODE_CLIENT),
             self::CHRONOPOST_HOME_DELIVERY_PASSWORD                   => ChronopostHomeDelivery::getConfigValue(self::CHRONOPOST_HOME_DELIVERY_PASSWORD),
+
+            /** Tracking link mask URL */
+            self::CHRONOPOST_HOME_DELIVERY_MASK_URL                   => ChronopostHomeDelivery::getConfigValue(self::CHRONOPOST_HOME_DELIVERY_MASK_URL),
 
             /** END */
         ];

--- a/Controller/ChronopostHomeDeliveryBackOfficeController.php
+++ b/Controller/ChronopostHomeDeliveryBackOfficeController.php
@@ -3,7 +3,6 @@
 namespace ChronopostHomeDelivery\Controller;
 
 
-use ApyVoucherShipments\Model\ApyShipper;
 use ChronopostHomeDelivery\ChronopostHomeDelivery;
 use ChronopostHomeDelivery\Config\ChronopostHomeDeliveryConst;
 use ChronopostHomeDelivery\Form\ChronopostHomeDeliveryConfigurationForm;
@@ -65,7 +64,7 @@ class ChronopostHomeDeliveryBackOfficeController extends BaseAdminController
             $startMaskUrl = $data['start_mask_url'] ?? '';
             $endMaskUrl = $data['end_mask_url'] ?? '';
             $maskUrl = ($startMaskUrl !== '' || $endMaskUrl !== '')
-                ? $startMaskUrl . ApyShipper::MASK_SEPARATOR . $endMaskUrl
+                ? $startMaskUrl . ChronopostHomeDeliveryConst::MASK_SEPARATOR . $endMaskUrl
                 : '';
             ChronopostHomeDelivery::setConfigValue(
                 ChronopostHomeDeliveryConst::CHRONOPOST_HOME_DELIVERY_MASK_URL,

--- a/Controller/ChronopostHomeDeliveryBackOfficeController.php
+++ b/Controller/ChronopostHomeDeliveryBackOfficeController.php
@@ -3,6 +3,7 @@
 namespace ChronopostHomeDelivery\Controller;
 
 
+use ApyVoucherShipments\Model\ApyShipper;
 use ChronopostHomeDelivery\ChronopostHomeDelivery;
 use ChronopostHomeDelivery\Config\ChronopostHomeDeliveryConst;
 use ChronopostHomeDelivery\Form\ChronopostHomeDeliveryConfigurationForm;
@@ -59,6 +60,17 @@ class ChronopostHomeDeliveryBackOfficeController extends BaseAdminController
             /** Basic informations */
             ChronopostHomeDelivery::setConfigValue(ChronopostHomeDeliveryConst::CHRONOPOST_HOME_DELIVERY_CODE_CLIENT, $data[ChronopostHomeDeliveryConst::CHRONOPOST_HOME_DELIVERY_CODE_CLIENT]);
             ChronopostHomeDelivery::setConfigValue(ChronopostHomeDeliveryConst::CHRONOPOST_HOME_DELIVERY_PASSWORD, $data[ChronopostHomeDeliveryConst::CHRONOPOST_HOME_DELIVERY_PASSWORD]);
+
+            /** Tracking link mask URL (concatenation start.MASK_SEPARATOR.end, or '' if both empty) */
+            $startMaskUrl = $data['start_mask_url'] ?? '';
+            $endMaskUrl = $data['end_mask_url'] ?? '';
+            $maskUrl = ($startMaskUrl || $endMaskUrl)
+                ? $startMaskUrl . ApyShipper::MASK_SEPARATOR . $endMaskUrl
+                : '';
+            ChronopostHomeDelivery::setConfigValue(
+                ChronopostHomeDeliveryConst::CHRONOPOST_HOME_DELIVERY_MASK_URL,
+                $maskUrl
+            );
 
             /** Delivery types */
             foreach (ChronopostHomeDeliveryConst::getDeliveryTypesStatusKeys() as $statusKey) {

--- a/Controller/ChronopostHomeDeliveryBackOfficeController.php
+++ b/Controller/ChronopostHomeDeliveryBackOfficeController.php
@@ -64,7 +64,7 @@ class ChronopostHomeDeliveryBackOfficeController extends BaseAdminController
             /** Tracking link mask URL (concatenation start.MASK_SEPARATOR.end, or '' if both empty) */
             $startMaskUrl = $data['start_mask_url'] ?? '';
             $endMaskUrl = $data['end_mask_url'] ?? '';
-            $maskUrl = ($startMaskUrl || $endMaskUrl)
+            $maskUrl = ($startMaskUrl !== '' || $endMaskUrl !== '')
                 ? $startMaskUrl . ApyShipper::MASK_SEPARATOR . $endMaskUrl
                 : '';
             ChronopostHomeDelivery::setConfigValue(

--- a/Form/ChronopostHomeDeliveryConfigurationForm.php
+++ b/Form/ChronopostHomeDeliveryConfigurationForm.php
@@ -3,11 +3,16 @@
 namespace ChronopostHomeDelivery\Form;
 
 
+use ApyVoucherShipments\Model\ApyShipper;
+use ChronopostHomeDelivery\ChronopostHomeDelivery;
 use ChronopostHomeDelivery\Config\ChronopostHomeDeliveryConst;
 use ChronopostHomeDelivery\Model\ChronopostHomeDeliveryDeliveryModeQuery;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\PasswordType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\Extension\Core\Type\UrlType;
+use Symfony\Component\Validator\Constraints\Callback;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
 use Thelia\Core\Translation\Translator;
 use Thelia\Form\BaseForm;
 use Thelia\Model\LangQuery;
@@ -52,6 +57,36 @@ class ChronopostHomeDeliveryConfigurationForm extends BaseForm
             )
         ;
 
+        /** Tracking link — start/end URL split from the concatenated config value */
+        $maskUrlConfig = $config[ChronopostHomeDeliveryConst::CHRONOPOST_HOME_DELIVERY_MASK_URL];
+        $maskUrlParts = $maskUrlConfig
+            ? preg_split('{' . ApyShipper::MASK_SEPARATOR . '}', $maskUrlConfig)
+            : ['', ''];
+        $startMaskUrl = $maskUrlParts[0] ?? '';
+        $endMaskUrl = $maskUrlParts[1] ?? '';
+
+        $this->formBuilder
+            ->add('start_mask_url', UrlType::class, [
+                'required' => false,
+                'data'     => $startMaskUrl,
+                'label'    => Translator::getInstance()->trans(
+                    'Start URL',
+                    [],
+                    ChronopostHomeDelivery::DOMAIN_NAME
+                ),
+            ])
+            ->add('end_mask_url', TextType::class, [
+                'required'    => false,
+                'data'        => $endMaskUrl,
+                'label'       => Translator::getInstance()->trans(
+                    'End URL',
+                    [],
+                    ChronopostHomeDelivery::DOMAIN_NAME
+                ),
+                'constraints' => [new Callback(['callback' => [$this, 'verifyStartMaskUrl']])],
+            ])
+        ;
+
         $lang = $this->getRequest()->getSession()->get('thelia.current.admin_lang');
         if (null === $lang) {
             $lang = LangQuery::create()
@@ -85,5 +120,22 @@ class ChronopostHomeDeliveryConfigurationForm extends BaseForm
     public static function getName(): string
     {
         return "chronopost_home_delivery_configuration_form";
+    }
+
+    public function verifyStartMaskUrl(
+        /** @noinspection PhpUnusedParameterInspection */ $value,
+        ExecutionContextInterface $context
+    ) {
+        $data = $context->getRoot()->getData();
+
+        if (!empty($data['end_mask_url']) && empty($data['start_mask_url'])) {
+            $context->addViolation(
+                Translator::getInstance()->trans(
+                    'End URL cannot be set without a Start URL',
+                    [],
+                    ChronopostHomeDelivery::DOMAIN_NAME
+                )
+            );
+        }
     }
 }

--- a/Form/ChronopostHomeDeliveryConfigurationForm.php
+++ b/Form/ChronopostHomeDeliveryConfigurationForm.php
@@ -4,6 +4,7 @@ namespace ChronopostHomeDelivery\Form;
 
 
 use ApyVoucherShipments\Model\ApyShipper;
+use ChronopostHomeDelivery\ChronopostHomeDelivery;
 use ChronopostHomeDelivery\Config\ChronopostHomeDeliveryConst;
 use ChronopostHomeDelivery\Model\ChronopostHomeDeliveryDeliveryModeQuery;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
@@ -59,7 +60,7 @@ class ChronopostHomeDeliveryConfigurationForm extends BaseForm
         /** Tracking link — start/end URL split from the concatenated config value */
         $maskUrlConfig = $config[ChronopostHomeDeliveryConst::CHRONOPOST_HOME_DELIVERY_MASK_URL];
         $maskUrlParts = $maskUrlConfig
-            ? preg_split('{' . ApyShipper::MASK_SEPARATOR . '}', $maskUrlConfig)
+            ? explode(ApyShipper::MASK_SEPARATOR, $maskUrlConfig, 2)
             : ['', ''];
         $startMaskUrl = $maskUrlParts[0] ?? '';
         $endMaskUrl = $maskUrlParts[1] ?? '';
@@ -71,7 +72,7 @@ class ChronopostHomeDeliveryConfigurationForm extends BaseForm
                 'label'    => Translator::getInstance()->trans(
                     'Start URL',
                     [],
-                    'chronoposthomedelivery.bo.default'
+                    ChronopostHomeDelivery::BO_DOMAIN_NAME
                 ),
             ])
             ->add('end_mask_url', TextType::class, [
@@ -80,7 +81,7 @@ class ChronopostHomeDeliveryConfigurationForm extends BaseForm
                 'label'       => Translator::getInstance()->trans(
                     'End URL',
                     [],
-                    'chronoposthomedelivery.bo.default'
+                    ChronopostHomeDelivery::BO_DOMAIN_NAME
                 ),
                 'constraints' => [new Callback(['callback' => [$this, 'verifyStartMaskUrl']])],
             ])
@@ -132,7 +133,7 @@ class ChronopostHomeDeliveryConfigurationForm extends BaseForm
                 Translator::getInstance()->trans(
                     'End URL cannot be set without a Start URL',
                     [],
-                    'chronoposthomedelivery.bo.default'
+                    ChronopostHomeDelivery::BO_DOMAIN_NAME
                 )
             );
         }

--- a/Form/ChronopostHomeDeliveryConfigurationForm.php
+++ b/Form/ChronopostHomeDeliveryConfigurationForm.php
@@ -74,6 +74,9 @@ class ChronopostHomeDeliveryConfigurationForm extends BaseForm
                     [],
                     ChronopostHomeDelivery::BO_DOMAIN_NAME
                 ),
+                'attr'     => [
+                    'data-chronopost-mask-role' => 'prefix',
+                ],
             ])
             ->add('end_mask_url', TextType::class, [
                 'required'    => false,
@@ -83,6 +86,9 @@ class ChronopostHomeDeliveryConfigurationForm extends BaseForm
                     [],
                     ChronopostHomeDelivery::BO_DOMAIN_NAME
                 ),
+                'attr'        => [
+                    'data-chronopost-mask-role' => 'suffix',
+                ],
                 'constraints' => [new Callback(['callback' => [$this, 'verifyStartMaskUrl']])],
             ])
         ;

--- a/Form/ChronopostHomeDeliveryConfigurationForm.php
+++ b/Form/ChronopostHomeDeliveryConfigurationForm.php
@@ -3,7 +3,6 @@
 namespace ChronopostHomeDelivery\Form;
 
 
-use ApyVoucherShipments\Model\ApyShipper;
 use ChronopostHomeDelivery\ChronopostHomeDelivery;
 use ChronopostHomeDelivery\Config\ChronopostHomeDeliveryConst;
 use ChronopostHomeDelivery\Model\ChronopostHomeDeliveryDeliveryModeQuery;
@@ -60,7 +59,7 @@ class ChronopostHomeDeliveryConfigurationForm extends BaseForm
         /** Tracking link — start/end URL split from the concatenated config value */
         $maskUrlConfig = $config[ChronopostHomeDeliveryConst::CHRONOPOST_HOME_DELIVERY_MASK_URL];
         $maskUrlParts = $maskUrlConfig
-            ? explode(ApyShipper::MASK_SEPARATOR, $maskUrlConfig, 2)
+            ? explode(ChronopostHomeDeliveryConst::MASK_SEPARATOR, $maskUrlConfig, 2)
             : ['', ''];
         $startMaskUrl = $maskUrlParts[0] ?? '';
         $endMaskUrl = $maskUrlParts[1] ?? '';

--- a/Form/ChronopostHomeDeliveryConfigurationForm.php
+++ b/Form/ChronopostHomeDeliveryConfigurationForm.php
@@ -4,7 +4,6 @@ namespace ChronopostHomeDelivery\Form;
 
 
 use ApyVoucherShipments\Model\ApyShipper;
-use ChronopostHomeDelivery\ChronopostHomeDelivery;
 use ChronopostHomeDelivery\Config\ChronopostHomeDeliveryConst;
 use ChronopostHomeDelivery\Model\ChronopostHomeDeliveryDeliveryModeQuery;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
@@ -72,7 +71,7 @@ class ChronopostHomeDeliveryConfigurationForm extends BaseForm
                 'label'    => Translator::getInstance()->trans(
                     'Start URL',
                     [],
-                    ChronopostHomeDelivery::DOMAIN_NAME
+                    'chronoposthomedelivery.bo.default'
                 ),
             ])
             ->add('end_mask_url', TextType::class, [
@@ -81,7 +80,7 @@ class ChronopostHomeDeliveryConfigurationForm extends BaseForm
                 'label'       => Translator::getInstance()->trans(
                     'End URL',
                     [],
-                    ChronopostHomeDelivery::DOMAIN_NAME
+                    'chronoposthomedelivery.bo.default'
                 ),
                 'constraints' => [new Callback(['callback' => [$this, 'verifyStartMaskUrl']])],
             ])
@@ -133,7 +132,7 @@ class ChronopostHomeDeliveryConfigurationForm extends BaseForm
                 Translator::getInstance()->trans(
                     'End URL cannot be set without a Start URL',
                     [],
-                    ChronopostHomeDelivery::DOMAIN_NAME
+                    'chronoposthomedelivery.bo.default'
                 )
             );
         }

--- a/I18n/backOffice/default/en_US.php
+++ b/I18n/backOffice/default/en_US.php
@@ -8,5 +8,10 @@ If you don't specify a cart weight in a slice, it will have priority over the sl
 If you don't specify a cart price in a slice, it will have priority over the other slices with the same weight. 
 If you specify both, the cart will require to have a lower weight AND a lower price in order to match the slice.
 TXT
-
+    ,
+    'Tracking link creation'                          => 'Tracking link creation',
+    'Start URL'                                       => 'Start URL',
+    'End URL'                                         => 'End URL',
+    'Preview: '                                       => 'Preview: ',
+    'End URL cannot be set without a Start URL'       => 'End URL cannot be set without a Start URL'
 ];

--- a/I18n/backOffice/default/fr_FR.php
+++ b/I18n/backOffice/default/fr_FR.php
@@ -28,5 +28,10 @@ Si vous ne spécifiez pas de prix dans une tranche, elle aura la priorité sur l
 Si vous spécifiez à la fois un poids et un prix, le panier devra avoir "un poids inférieur et un prix inférieur" pour que la tranche soit appliquée.
 TXT,
     'Area not found'                                  => 'Zone de livraison non trouvée',
-    'Delivery mode not found'                         => 'Mode de livraison non trouvé'
+    'Delivery mode not found'                         => 'Mode de livraison non trouvé',
+    'Tracking link creation'                          => 'Création du lien de suivi',
+    'Start URL'                                       => 'URL de début',
+    'End URL'                                         => 'URL de fin',
+    'Preview: '                                       => 'Aperçu : ',
+    'End URL cannot be set without a Start URL'       => 'L\'URL de fin ne peut être saisie sans une URL de début'
 ];

--- a/I18n/backOffice/default/fr_FR.php
+++ b/I18n/backOffice/default/fr_FR.php
@@ -30,8 +30,8 @@ TXT,
     'Area not found'                                  => 'Zone de livraison non trouvée',
     'Delivery mode not found'                         => 'Mode de livraison non trouvé',
     'Tracking link creation'                          => 'Création du lien de suivi',
-    'Start URL'                                       => 'URL de début',
-    'End URL'                                         => 'URL de fin',
+    'Start URL'                                       => 'Début du lien de suivi',
+    'End URL'                                         => 'Fin du lien de suivi',
     'Preview: '                                       => 'Aperçu : ',
     'End URL cannot be set without a Start URL'       => 'L\'URL de fin ne peut être saisie sans une URL de début'
 ];

--- a/I18n/backOffice/default/fr_FR.php
+++ b/I18n/backOffice/default/fr_FR.php
@@ -32,6 +32,6 @@ TXT,
     'Tracking link creation'                          => 'Création du lien de suivi',
     'Start URL'                                       => 'Début du lien de suivi',
     'End URL'                                         => 'Fin du lien de suivi',
-    'Preview: '                                       => 'Aperçu : ',
+    'Preview: '                                       => 'Prévisualisation du lien de suivi : ',
     'End URL cannot be set without a Start URL'       => 'L\'URL de fin ne peut être saisie sans une URL de début'
 ];

--- a/templates/backOffice/default/ChronopostHomeDelivery/ChronopostHomeDeliveryAdvancedConfig.html
+++ b/templates/backOffice/default/ChronopostHomeDelivery/ChronopostHomeDeliveryAdvancedConfig.html
@@ -3,11 +3,11 @@
     {form name="chronopost_home_delivery_configuration_form" type="chronopost_home_delivery_configuration_form"}
         <form class="chronopost-home-delivery-configuration-form" action="{url path='/admin/module/ChronopostHomeDelivery/config'}" method="post">
             <div class="title">{intl l="Chronopost informations"}</div>
-                {include
-                file      = "includes/inner-form-toolbar.html"
+            {include
+                file       = "includes/inner-form-toolbar.html"
                 hide_flags = true
                 hide_save_and_close_button = true
-                }
+            }
             <div class="panel panel-default">
                 <div class="panel-heading">
                     <div class="panel-title">{intl l="Service Configuration" d='chronoposthomedelivery.bo.default'}</div>
@@ -28,12 +28,11 @@
 
                             <div class="form-group">
                                 {form_field field="chronopost_home_delivery_password"}
-
-                                <label for="{$name}" class="control-label">{$label}{if $required} <span class="required">*</span>{/if} : </label>
-                                <input type="password" id="mdp" name="{$name}" class="form-control" value="{$data}" placeholder="Your Chronopost password" aria-describedby="pwdHelpBlock">
-                                <button type="button" class="eye btn btn-primary btn-responsive" style="color:#FFF;background-color:#f6993c" onclick="togglePwd('mdp');">
-                                    <i class="glyphicon glyphicon-eye-open"></i>
-                                </button>
+                                    <label for="{$name}" class="control-label">{$label}{if $required} <span class="required">*</span>{/if} : </label>
+                                    <input type="password" id="mdp" name="{$name}" class="form-control" value="{$data}" placeholder="Your Chronopost password" aria-describedby="pwdHelpBlock">
+                                    <button type="button" class="eye btn btn-primary btn-responsive" style="color:#FFF;background-color:#f6993c" data-toggle-password-target="mdp">
+                                        <i class="glyphicon glyphicon-eye-open"></i>
+                                    </button>
                                 {/form_field}
                             </div>
                         </div>
@@ -48,73 +47,25 @@
                         </div>
                     </div>
 
-                            <div class="well">
-                                <h3>{intl l='Tracking link creation' d='chronoposthomedelivery.bo.default'}</h3>
-                                <div class="row">
-                                    <div class="col-xs-12 col-sm-6">
-                                        {render_form_field field='start_mask_url'}
-                                    </div>
-                                    <div class="col-xs-12 col-sm-6">
-                                        {render_form_field field='end_mask_url'}
-                                    </div>
-                                </div>
-                                <div class="chronopost-mask-url-wrapper">
-                                    <small>{intl l='Preview: ' d='chronoposthomedelivery.bo.default'}
-                                        <strong class="chronopost-mask-url-preview"></strong>
-                                    </small>
-                                </div>
+                    <div class="well">
+                        <h3>{intl l='Tracking link creation' d='chronoposthomedelivery.bo.default'}</h3>
+                        <div class="row">
+                            <div class="col-xs-12 col-sm-6">
+                                {render_form_field field='start_mask_url'}
                             </div>
+                            <div class="col-xs-12 col-sm-6">
+                                {render_form_field field='end_mask_url'}
+                            </div>
+                        </div>
+                        <div class="chronopost-mask-url-wrapper">
+                            <small>
+                                {intl l='Preview: ' d='chronoposthomedelivery.bo.default'}
+                                <strong class="chronopost-mask-url-preview"></strong>
+                            </small>
+                        </div>
+                    </div>
                 </div>
             </div>
         </form>
     {/form}
 </div>
-
-<script>
-    function togglePwd(id)
-    {
-        var x = document.getElementById(id);
-        x.type = (x.type === "password")? "text" : "password";
-    }
-
-    (function () {
-        function chronopostMaskUrlInit() {
-            var inputs = document.querySelectorAll('[data-chronopost-mask-role]');
-            var preview = document.querySelector('.chronopost-mask-url-preview');
-            console.log('[chronopost-preview] init', { inputs: inputs.length, preview: !!preview });
-            if (!preview || inputs.length === 0) {
-                return;
-            }
-            function refresh() {
-                var prefix = '';
-                var suffix = '';
-                inputs.forEach(function (el) {
-                    if (el.getAttribute('data-chronopost-mask-role') === 'prefix') {
-                        prefix = el.value || '';
-                    }
-                    if (el.getAttribute('data-chronopost-mask-role') === 'suffix') {
-                        suffix = el.value || '';
-                    }
-                });
-                if (prefix !== '' || suffix !== '') {
-                    preview.textContent = prefix + 'XXXXXXXXXXXXX' + suffix;
-                    preview.style.display = '';
-                } else {
-                    preview.textContent = '';
-                    preview.style.display = 'none';
-                }
-            }
-            inputs.forEach(function (el) {
-                el.addEventListener('input', refresh);
-                el.addEventListener('change', refresh);
-                el.addEventListener('keyup', refresh);
-            });
-            refresh();
-        }
-        if (document.readyState === 'loading') {
-            document.addEventListener('DOMContentLoaded', chronopostMaskUrlInit);
-        } else {
-            chronopostMaskUrlInit();
-        }
-    })();
-</script>

--- a/templates/backOffice/default/ChronopostHomeDelivery/ChronopostHomeDeliveryAdvancedConfig.html
+++ b/templates/backOffice/default/ChronopostHomeDelivery/ChronopostHomeDeliveryAdvancedConfig.html
@@ -47,6 +47,27 @@
                             {/foreach}
                         </div>
                     </div>
+
+                    <div class="row">
+                        <div class="col-md-12">
+                            <div class="well">
+                                <h3>{intl l='Tracking link creation' d='chronoposthomedelivery.bo.default'}</h3>
+                                <div class="row">
+                                    <div class="col-xs-12 col-sm-6">
+                                        {render_form_field field='start_mask_url' extra_class='chronopost-mask-url-content chronopost-mask-url-prefix'}
+                                    </div>
+                                    <div class="col-xs-12 col-sm-6">
+                                        {render_form_field field='end_mask_url' extra_class='chronopost-mask-url-content chronopost-mask-url-suffix'}
+                                    </div>
+                                </div>
+                                <div class="chronopost-mask-url-wrapper">
+                                    <small>{intl l='Preview: ' d='chronoposthomedelivery.bo.default'}
+                                        <strong class="chronopost-mask-url-preview"></strong>
+                                    </small>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
                 </div>
             </div>
         </form>
@@ -59,4 +80,27 @@
         var x = document.getElementById(id);
         x.type = (x.type === "password")? "text" : "password";
     }
+
+    (function ($) {
+        function chronopostMaskUrlPreview() {
+            var prefix = '', suffix = '';
+            var $preview = $('.chronopost-mask-url-preview');
+            $preview.hide();
+            $('.chronopost-mask-url-content').each(function () {
+                var $el = $(this);
+                if ($el.hasClass('chronopost-mask-url-prefix') && $el.val()) {
+                    prefix = $el.val();
+                }
+                if ($el.hasClass('chronopost-mask-url-suffix') && $el.val()) {
+                    suffix = $el.val();
+                }
+            });
+            if (prefix || suffix) {
+                $preview.text(prefix + 'XXXXXXXXXXXXX' + suffix).show();
+            }
+        }
+        $(document)
+            .ready(chronopostMaskUrlPreview)
+            .on('change keyup', '.chronopost-mask-url-content', chronopostMaskUrlPreview);
+    })(jQuery);
 </script>

--- a/templates/backOffice/default/ChronopostHomeDelivery/ChronopostHomeDeliveryAdvancedConfig.html
+++ b/templates/backOffice/default/ChronopostHomeDelivery/ChronopostHomeDeliveryAdvancedConfig.html
@@ -54,10 +54,10 @@
                                 <h3>{intl l='Tracking link creation' d='chronoposthomedelivery.bo.default'}</h3>
                                 <div class="row">
                                     <div class="col-xs-12 col-sm-6">
-                                        {render_form_field field='start_mask_url' extra_class='chronopost-mask-url-content chronopost-mask-url-prefix'}
+                                        {render_form_field field='start_mask_url'}
                                     </div>
                                     <div class="col-xs-12 col-sm-6">
-                                        {render_form_field field='end_mask_url' extra_class='chronopost-mask-url-content chronopost-mask-url-suffix'}
+                                        {render_form_field field='end_mask_url'}
                                     </div>
                                 </div>
                                 <div class="chronopost-mask-url-wrapper">
@@ -81,26 +81,44 @@
         x.type = (x.type === "password")? "text" : "password";
     }
 
-    (function ($) {
-        function chronopostMaskUrlPreview() {
-            var prefix = '', suffix = '';
-            var $preview = $('.chronopost-mask-url-preview');
-            $preview.hide();
-            $('.chronopost-mask-url-content').each(function () {
-                var $el = $(this);
-                if ($el.hasClass('chronopost-mask-url-prefix') && $el.val()) {
-                    prefix = $el.val();
-                }
-                if ($el.hasClass('chronopost-mask-url-suffix') && $el.val()) {
-                    suffix = $el.val();
-                }
-            });
-            if (prefix || suffix) {
-                $preview.text(prefix + 'XXXXXXXXXXXXX' + suffix).show();
+    (function () {
+        function chronopostMaskUrlInit() {
+            var inputs = document.querySelectorAll('[data-chronopost-mask-role]');
+            var preview = document.querySelector('.chronopost-mask-url-preview');
+            console.log('[chronopost-preview] init', { inputs: inputs.length, preview: !!preview });
+            if (!preview || inputs.length === 0) {
+                return;
             }
+            function refresh() {
+                var prefix = '';
+                var suffix = '';
+                inputs.forEach(function (el) {
+                    if (el.getAttribute('data-chronopost-mask-role') === 'prefix') {
+                        prefix = el.value || '';
+                    }
+                    if (el.getAttribute('data-chronopost-mask-role') === 'suffix') {
+                        suffix = el.value || '';
+                    }
+                });
+                if (prefix !== '' || suffix !== '') {
+                    preview.textContent = prefix + 'XXXXXXXXXXXXX' + suffix;
+                    preview.style.display = '';
+                } else {
+                    preview.textContent = '';
+                    preview.style.display = 'none';
+                }
+            }
+            inputs.forEach(function (el) {
+                el.addEventListener('input', refresh);
+                el.addEventListener('change', refresh);
+                el.addEventListener('keyup', refresh);
+            });
+            refresh();
         }
-        $(document)
-            .ready(chronopostMaskUrlPreview)
-            .on('change keyup', '.chronopost-mask-url-content', chronopostMaskUrlPreview);
-    })(jQuery);
+        if (document.readyState === 'loading') {
+            document.addEventListener('DOMContentLoaded', chronopostMaskUrlInit);
+        } else {
+            chronopostMaskUrlInit();
+        }
+    })();
 </script>

--- a/templates/backOffice/default/ChronopostHomeDelivery/ChronopostHomeDeliveryAdvancedConfig.html
+++ b/templates/backOffice/default/ChronopostHomeDelivery/ChronopostHomeDeliveryAdvancedConfig.html
@@ -48,8 +48,6 @@
                         </div>
                     </div>
 
-                    <div class="row">
-                        <div class="col-md-12">
                             <div class="well">
                                 <h3>{intl l='Tracking link creation' d='chronoposthomedelivery.bo.default'}</h3>
                                 <div class="row">
@@ -66,8 +64,6 @@
                                     </small>
                                 </div>
                             </div>
-                        </div>
-                    </div>
                 </div>
             </div>
         </form>

--- a/templates/backOffice/default/ChronopostHomeDelivery/module-config-js.html
+++ b/templates/backOffice/default/ChronopostHomeDelivery/module-config-js.html
@@ -6,6 +6,14 @@
     <script src="{$asset_url}"></script>
 {/javascripts}
 
+{javascripts file='assets/js/password-toggle.js' source='ChronopostHomeDelivery' template="default"}
+    <script src='{$asset_url}'></script>
+{/javascripts}
+
+{javascripts file='assets/js/tracking-link-preview.js' source='ChronopostHomeDelivery' template="default"}
+    <script src='{$asset_url}'></script>
+{/javascripts}
+
 
 <script>
 

--- a/templates/backOffice/default/assets/js/password-toggle.js
+++ b/templates/backOffice/default/assets/js/password-toggle.js
@@ -1,0 +1,41 @@
+/* globals jQuery */
+
+/**
+ * Toggle de visibilité d'un champ password ChronopostHomeDelivery.
+ *
+ * Usage HTML :
+ *   <input type="password" id="mdp" ...>
+ *   <button data-toggle-password-target="mdp">...</button>
+ *
+ * Le bouton bascule l'attribut `type` du champ ciblé entre `password` et `text`.
+ * Event delegation sur `document` pour supporter les boutons ajoutés dynamiquement.
+ */
+(function ($) {
+    'use strict';
+
+    /**
+     * Inverse le type de l'input ciblé par l'attribut `data-toggle-password-target`
+     * du bouton qui a déclenché l'événement (`this`).
+     *
+     * @returns {void}
+     */
+    function togglePassword() {
+        // Identifiant du champ à toggler, déclaré sur le bouton
+        var targetId = $(this).data('toggle-password-target');
+        if (!targetId) {
+            return;
+        }
+
+        var $input = $('#' + targetId);
+        if ($input.length === 0) {
+            return;
+        }
+
+        // Bascule password <-> text sans toucher aux autres attributs
+        $input.attr('type', $input.attr('type') === 'password' ? 'text' : 'password');
+    }
+
+    // Event delegation : un seul listener sur document, déclenché par n'importe quel bouton
+    // portant l'attribut data-toggle-password-target (présent ou ajouté plus tard au DOM)
+    $(document).on('click', '[data-toggle-password-target]', togglePassword);
+})(jQuery);

--- a/templates/backOffice/default/assets/js/tracking-link-preview.js
+++ b/templates/backOffice/default/assets/js/tracking-link-preview.js
@@ -1,0 +1,48 @@
+/* globals jQuery */
+
+/**
+ * Prévisualisation live du lien de suivi Chronopost.
+ *
+ * Le champ « URL de tracking » est saisi en deux parties (préfixe + suffixe)
+ * concaténées côté backend autour du placeholder ChronopostHomeDeliveryConst::MASK_SEPARATOR (`{REF}`).
+ * Ce script affiche en temps réel le rendu final que verra le client, en remplaçant
+ * le placeholder par une suite de X pour matérialiser l'emplacement de la référence colis.
+ *
+ * Sélecteurs HTML attendus (déclarés via `attr` Symfony côté ChronopostHomeDeliveryConfigurationForm) :
+ *   - <input data-chronopost-mask-role="prefix"> : début de l'URL
+ *   - <input data-chronopost-mask-role="suffix"> : fin de l'URL
+ *   - <strong class="chronopost-mask-url-preview"> : zone d'affichage du rendu
+ */
+(function ($) {
+    'use strict';
+
+    var SELECTOR = '[data-chronopost-mask-role]';
+    // Placeholder visuel substitué à MASK_SEPARATOR pour l'aperçu admin
+    var PLACEHOLDER = 'XXXXXXXXXXXXX';
+
+    /**
+     * Recalcule et réaffiche la prévisualisation à partir des valeurs courantes
+     * des deux champs. Cache le bloc preview si les deux champs sont vides.
+     *
+     * @returns {void}
+     */
+    function refresh() {
+        var prefix = $('[data-chronopost-mask-role="prefix"]').val() || '';
+        var suffix = $('[data-chronopost-mask-role="suffix"]').val() || '';
+        var $preview = $('.chronopost-mask-url-preview');
+
+        if (prefix !== '' || suffix !== '') {
+            $preview.text(prefix + PLACEHOLDER + suffix).show();
+        } else {
+            // Reset complet quand l'admin vide les deux champs
+            $preview.text('').hide();
+        }
+    }
+
+    // `ready` : rafraîchit au chargement initial.
+    // Event delegation : capte `input`, `change`, `keyup` pour couvrir paste, saisie clavier
+    // et auto-complétion navigateur.
+    $(document)
+        .ready(refresh)
+        .on('input change keyup', SELECTOR, refresh);
+})(jQuery);


### PR DESCRIPTION
### Type de MR
FEATURE

### Ticket
https://www.demandedesupport.com/issues/1219723

### Impact
utilisateur|consommateur

### Phrase de description dans le mail de livraison
`Ajouter création lien de suivi dans module ChronopostHomeDelivery` 

### Procédure de tests
+ Tester la nouvelle section : `Modes de livraison -> Configuration Chronopost/Chronofresh/Chronofreeze -> "Création du lien de suivi"` 
  + La prévisualisation en direct doit fonctionner
  + Vous ne pouvez pas rentrer de fin de lien si il n'y a pas de debut
  + La soumission de formulaire créer une config pour le module, CF BDD -> `module_config` et `module_config_i18n` (chronopost_home_delivery_mask_url)
+ Créer une nouvelle commande chronopost : (nécessaire pour avoir les bonnes infos dans `apy_shipment_details.shipper_mask_url` de l'order product)
  + BO -> Suivre les commandes -> Produits à expedier : 
    + Quand vous marquer comme expédié : 
      + Le numéro du colis s'ajout au milieu du lien
      + Si nouveau lien de suivi, il est remplacé par ce dernier
  + Vous retrouvez le lien : 
    + Dans le mail transactionnel que vous allez recevoir
    + Sur le bouton d'action du camion gris : BO -> Suivre les commandes -> Suivi des expeditions
+ Vous pouvez aussi tester avec un transporteur classique, il ne doit pas y avoir d'impact

### Explication plus technique
+ Ajout d'une nouvelle section "Création du lien de suivi" pour gérer les livraisons par chronopost

### Lié aux MR ::
+ https://git.centraldev.api-and-you.com/apymybox/apymybox/-/merge_requests/3522
+ https://github.com/lesateliersapicius/ChronopostHomeDelivery/pull/3